### PR TITLE
suppression des icones au header responsive sur mobile

### DIFF
--- a/application/views/front/landing/accueil.php
+++ b/application/views/front/landing/accueil.php
@@ -79,6 +79,10 @@
                 --title-scale: 0.7;
             }
 
+            .header__navCtas{
+                display: none;
+            }
+
             /* #headerMenuButton{
                     display: block;
                 }


### PR DESCRIPTION
suppression des icones dans l'entête pour le responsive a partir des écrans 750px 