### PR TITLE
Correctif apprenant : affichage correct

### DIFF
--- a/application/controllers/Gestionnaire.php
+++ b/application/controllers/Gestionnaire.php
@@ -54,8 +54,15 @@ class Gestionnaire extends CI_Controller
 		foreach($candidats as $candidat)
 		{
 			$montant_candidat = $this->paiement_model->recuperer_tout_le_montant($candidat->id_can);
-			if ($montant_candidat == 155000) {
-				$nb_apprenants++;
+
+			if ($candidat->type_cours == 'P') {
+				if ($montant_candidat > 0) {
+					$nb_apprenants++;
+				}
+			} else {
+				if($montant_candidat == PRIX_EN_LIGNE){
+					$nb_apprenants++;
+				} 
 			}
 		}
 


### PR DESCRIPTION
L'affichage des apprenants se fait maintenant selon la nouvelle logique : 
- On devient apprenant si on est candidat en ligne et qu'on a paye 90 000 F CFA
- On devient apprenant si on candidat en présentiel et qu'on a paye une tranche 