### PR TITLE
Correctif de connexion gestionnaire

### DIFF
--- a/application/controllers/Gestionnaire.php
+++ b/application/controllers/Gestionnaire.php
@@ -98,6 +98,7 @@ class Gestionnaire extends CI_Controller
 	public function connexion()
 	{
 		if (est_connecte()) {
+			$this->session->sess_destroy();
 			redirect('gestionnaire');
 		} else {
 			$this->session->sess_destroy();


### PR DESCRIPTION
On détruit les sessions pour la connexion Gestionnaire pour éviter  **ERR_TOO_MANY_REDIRECTS** 