### PR TITLE
Correctif: historique des transactions candidats

### DIFF
--- a/application/controllers/Gestionnaire.php
+++ b/application/controllers/Gestionnaire.php
@@ -407,6 +407,7 @@ class Gestionnaire extends CI_Controller
 				$paiement->nom_candidat = $candidat->nom_prenom;
 				$paiement->type = $candidat->type_cours;
 				$paiement->gestionnaire = $gestionnaire->nom_prenom;
+				$paiement->max_montant = $candidat->type_cours == 'P' ? PRIX_PRESENTIEL : PRIX_EN_LIGNE;
 			}
 		}
 

--- a/application/views/back/gestionnaire/transactions.php
+++ b/application/views/back/gestionnaire/transactions.php
@@ -32,7 +32,7 @@
                                     <td><?= $paiement->nom_candidat ?></td>
                                     <td><?= ($paiement->type == 'P') ? 'En presentiel' : 'En ligne' ?></td>
                                     <td><?= number_format($paiement->montant, 0, ',', ' ') ?> F CFA</td>
-                                    <td><?= number_format(150000 - $paiement->montant, 0,',',' ') ?> F CFA</td>
+                                    <td><?= number_format($paiement->max_montant - $paiement->montant, 0,',',' ') ?> F CFA</td>
                                     <td><?= $paiement->gestionnaire ?></td>
                                 </tr>
                             <?php endforeach; ?>


### PR DESCRIPTION
Un bug a été corrige au niveau de l'historique des transactions candidats . Il ne prenait pas en compte le montant maximale des candidats efficacement . 